### PR TITLE
Return initial fadein

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -6181,20 +6181,6 @@ bool FurnaceGUI::loop() {
     renderTimeEnd=SDL_GetPerformanceCounter();
     drawTimeBegin=SDL_GetPerformanceCounter();
     rend->renderGUI();
-
-    if (mustClear) {
-      rend->clear(ImVec4(0,0,0,0));
-      mustClear--;
-      if (mustClear==0) e->everythingOK();
-    } else {
-      if (initialScreenWipe>0.0f && !settings.disableFadeIn) {
-        WAKE_UP;
-        initialScreenWipe-=ImGui::GetIO().DeltaTime*5.0f;
-        if (initialScreenWipe>0.0f) {
-          rend->wipe(pow(initialScreenWipe,2.0f));
-        }
-      }
-    }
     
     drawTimeEnd=SDL_GetPerformanceCounter();
     rend->present();

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -6184,9 +6184,22 @@ bool FurnaceGUI::loop() {
 
     if (mustClear) 
     {
-        rend->clear(ImVec4(0, 0, 0, 0));
-        mustClear--;
-        if (mustClear == 0) e->everythingOK();
+      rend->clear(ImVec4(0, 0, 0, 0));
+      mustClear--;
+      if (mustClear == 0) e->everythingOK();
+    }
+
+    else
+    {
+      if (initialScreenWipe>0.0f && !settings.disableFadeIn)
+      {
+        WAKE_UP;
+        initialScreenWipe-=ImGui::GetIO().DeltaTime*5.0f;
+        if (initialScreenWipe>0.0f)
+        {
+          rend->wipe(pow(initialScreenWipe,2.0f));
+        }
+      }
     }
     
     drawTimeEnd=SDL_GetPerformanceCounter();
@@ -7516,6 +7529,7 @@ FurnaceGUI::FurnaceGUI():
   waveGenOffsetY(0),
   waveGenSmooth(1),
   mustClear(3),
+  initialScreenWipe(1.0f),
   waveGenAmplify(1.0f),
   waveGenFM(false) {
   // value keys

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -7528,10 +7528,10 @@ FurnaceGUI::FurnaceGUI():
   waveGenOffsetX(0),
   waveGenOffsetY(0),
   waveGenSmooth(1),
-  mustClear(3),
-  initialScreenWipe(1.0f),
   waveGenAmplify(1.0f),
-  waveGenFM(false) {
+  waveGenFM(false),
+  mustClear(3),
+  initialScreenWipe(1.0f) {
   // value keys
   valueKeys[SDLK_0]=0;
   valueKeys[SDLK_1]=1;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -6182,6 +6182,20 @@ bool FurnaceGUI::loop() {
     drawTimeBegin=SDL_GetPerformanceCounter();
     rend->renderGUI();
 
+    if (mustClear) {
+      rend->clear(ImVec4(0,0,0,0));
+      mustClear--;
+      if (mustClear==0) e->everythingOK();
+    } else {
+      if (initialScreenWipe>0.0f && !settings.disableFadeIn) {
+        WAKE_UP;
+        initialScreenWipe-=ImGui::GetIO().DeltaTime*5.0f;
+        if (initialScreenWipe>0.0f) {
+          rend->wipe(pow(initialScreenWipe,2.0f));
+        }
+      }
+    }
+    
     drawTimeEnd=SDL_GetPerformanceCounter();
     rend->present();
     if (settings.renderClearPos) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -6181,6 +6181,13 @@ bool FurnaceGUI::loop() {
     renderTimeEnd=SDL_GetPerformanceCounter();
     drawTimeBegin=SDL_GetPerformanceCounter();
     rend->renderGUI();
+
+    if (mustClear) 
+    {
+        rend->clear(ImVec4(0, 0, 0, 0));
+        mustClear--;
+        if (mustClear == 0) e->everythingOK();
+    }
     
     drawTimeEnd=SDL_GetPerformanceCounter();
     rend->present();
@@ -7508,6 +7515,7 @@ FurnaceGUI::FurnaceGUI():
   waveGenOffsetX(0),
   waveGenOffsetY(0),
   waveGenSmooth(1),
+  mustClear(3),
   waveGenAmplify(1.0f),
   waveGenFM(false) {
   // value keys

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2308,6 +2308,8 @@ class FurnaceGUI {
   bool waveGenFMCon4[5];
   bool waveGenFM;
 
+  int mustClear;
+
   // export options
   int audioExportType;
   FurnaceGUIExportTypes curExportType;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2309,6 +2309,7 @@ class FurnaceGUI {
   bool waveGenFM;
 
   int mustClear;
+  float initialScreenWipe;
 
   // export options
   int audioExportType;


### PR DESCRIPTION
On startup threee first frames must be hidden because for whatever reason UI there is not in final shape which produces annoying glitch. I returned the piece of code that masks these frames (and made it mask first three frames instead of first two as it was in tilde's Furnace version). Also a fadein setting now works again.