### PR TITLE
Fix YM2612 ch6 arp macro

### DIFF
--- a/src/engine/platform/genesis.cpp
+++ b/src/engine/platform/genesis.cpp
@@ -351,9 +351,16 @@ void DivPlatformGenesis::tick(bool sysTick) {
     if (i>=5 && chan[i].furnaceDac) {
       if (NEW_ARP_STRAT) {
         chan[i].handleArp();
-      } else if (chan[i].std.get_div_macro_struct(DIV_MACRO_ARP)->had) {
+      } else if (chan[i].std.get_div_macro_struct(DIV_MACRO_ARP)->had && chan[i].dacMode) {
         if (!chan[i].inPorta) {
           chan[i].baseFreq=parent->calcBaseFreq(1,1,parent->calcArp(chan[i].note,chan[i].std.get_div_macro_struct(DIV_MACRO_ARP)->val),false);
+        }
+        chan[i].freqChanged=true;
+      }
+      else //when Ch6 is not in DAC mode
+      {
+        if (!chan[i].inPorta) {
+          chan[i].baseFreq=NOTE_FNUM_BLOCK(parent->calcArp(chan[i].note,chan[i].std.get_div_macro_struct(DIV_MACRO_ARP)->val),11);
         }
         chan[i].freqChanged=true;
       }


### PR DESCRIPTION
Try with this module, order 0x14, inst 0x4, play with its arp macro (0, -1, -2, ...) and hear what happens when it's played on 6th channel.

[MAP08_-_Tower_of_Fire.zip](https://github.com/LTVA1/furnace/files/13871347/MAP08_-_Tower_of_Fire.zip)

This PR tries to fix the bug
