### PR TITLE
Local wavetables

### DIFF
--- a/src/engine/instrument.h
+++ b/src/engine/instrument.h
@@ -27,6 +27,8 @@
 #include "../pch.h"
 #include <vector>
 
+#include "wavetable.h"
+
 struct DivSong;
 
 // NOTICE!
@@ -348,6 +350,8 @@ struct DivInstrumentSTD
   };
 
   std::vector<OpMacro> ops;
+
+  std::vector<DivWavetable*> local_waves;
 
   OpMacro* get_op_macro(uint8_t index)
   {

--- a/src/gui/inst/wavetable.cpp
+++ b/src/gui/inst/wavetable.cpp
@@ -306,4 +306,100 @@ void FurnaceGUI::insTabWave(DivInstrument* ins)
 
         ImGui::EndTabItem();
     }
+
+    if (ImGui::BeginTabItem(_L("Local Waves##sgiwave"))) 
+    {
+        if (ImGui::Button(ICON_FA_PLUS "##WaveAdd")) 
+        {
+            doAction(GUI_ACTION_WAVE_LIST_ADD);
+        }
+        if (ImGui::IsItemHovered()) 
+        {
+            ImGui::SetTooltip(_L("Add##sgdl1"));
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(ICON_FA_FILES_O "##WaveClone")) 
+        {
+            doAction(GUI_ACTION_WAVE_LIST_DUPLICATE);
+        }
+        if (ImGui::IsItemHovered()) 
+        {
+            ImGui::SetTooltip(_L("Duplicate##sgdl3"));
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(ICON_FA_FOLDER_OPEN "##WaveLoad")) 
+        {
+            doAction(GUI_ACTION_WAVE_LIST_OPEN);
+        }
+        if (ImGui::IsItemHovered()) 
+        {
+            ImGui::SetTooltip(_L("Open##sgdl1"));
+        }
+        if (ImGui::BeginPopupContextItem("WaveOpenOpt")) 
+        {
+            if (ImGui::MenuItem(_L("replace...##sgdl3"))) 
+            {
+                doAction((curWave>=0 && curWave<(int)e->song.wave.size())?GUI_ACTION_WAVE_LIST_OPEN_REPLACE:GUI_ACTION_WAVE_LIST_OPEN);
+            }
+            ImGui::EndPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(ICON_FA_FLOPPY_O "##WaveSave")) 
+        {
+            doAction(GUI_ACTION_WAVE_LIST_SAVE);
+        }
+        if (ImGui::IsItemHovered()) 
+        {
+            ImGui::SetTooltip(_L("Save##sgdl3"));
+        }
+        if (ImGui::BeginPopupContextItem("WaveSaveFormats",ImGuiMouseButton_Right)) 
+        {
+            if (ImGui::MenuItem(_L("save as .dmw...##sgdl"))) 
+            {
+                doAction(GUI_ACTION_WAVE_LIST_SAVE_DMW);
+            }
+            if (ImGui::MenuItem(_L("save raw...##sgdl0"))) 
+            {
+                doAction(GUI_ACTION_WAVE_LIST_SAVE_RAW);
+            }
+            ImGui::EndPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(ICON_FA_ARROW_UP "##WaveUp")) 
+        {
+            doAction(GUI_ACTION_WAVE_LIST_MOVE_UP);
+        }
+        if (ImGui::IsItemHovered()) 
+        {
+            ImGui::SetTooltip(_L("Move up##sgdl1"));
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(ICON_FA_ARROW_DOWN "##WaveDown")) 
+        {
+            doAction(GUI_ACTION_WAVE_LIST_MOVE_DOWN);
+        }
+        if (ImGui::IsItemHovered()) 
+        {
+            ImGui::SetTooltip(_L("Move down##sgdl1"));
+        }
+        ImGui::SameLine();
+        pushDestColor();
+        if (ImGui::Button(ICON_FA_TIMES "##WaveDelete")) 
+        {
+            doAction(GUI_ACTION_WAVE_LIST_DELETE);
+        }
+        popDestColor();
+        if (ImGui::IsItemHovered()) 
+        {
+            ImGui::SetTooltip(_L("Delete##sgdl4"));
+        }
+        ImGui::Separator();
+        if (ImGui::BeginTable("WaveListScroll",1,ImGuiTableFlags_ScrollY)) 
+        {
+            actualWaveList();
+            ImGui::EndTable();
+        }
+
+        ImGui::EndTabItem();
+    }
 }

--- a/src/locale/russian.cpp
+++ b/src/locale/russian.cpp
@@ -4742,6 +4742,7 @@ void DivLocale::addTranslationsRussian()
     strings["Power##sgiwave"].plurals[0] = "Степень";
     strings["Global##sgiwave"].plurals[0] = "Глобально";
     strings["wavetable synthesizer disabled.\nuse the Waveform macro to set the wave for this instrument.##sgiwave"].plurals[0] = "синтезатор волновых таблиц выключен.\nиспользуйте макрос волны для задания волновой таблицы для этого инструмента.";
+    strings["Local Waves##sgiwave"].plurals[0] = "Локальные волн. табл.";
 
     //   sgiX1     src/gui/inst/x1_010.cpp
 

--- a/src/locale/template.cpp
+++ b/src/locale/template.cpp
@@ -4820,6 +4820,7 @@ void DivLocale::addTranslationsTemplate()
     strings["Power##sgiwave"].plurals[0] = "=Power";
     strings["Global##sgiwave"].plurals[0] = "=Global";
     strings["wavetable synthesizer disabled.\nuse the Waveform macro to set the wave for this instrument.##sgiwave"].plurals[0] = "=wavetable synthesizer disabled.\nuse the Waveform macro to set the wave for this instrument.";
+    strings["Local Waves##sgiwave"].plurals[0] = "=Local Waves";
 
     //   sgiX1     src/gui/inst/x1_010.cpp
 


### PR DESCRIPTION
Basically each instrument would have its own separate list of wavetables. Waveform macro would choose between local and global waves just like arp macro switches between relative and fixed modes.

Mainly stimulated by famitracker import improvements since in famitracker N163 waves are in per-instrument lists too, so there's a risk of not all waves fitting into current global wavetable list when importing famitracker module.

I am not sure if I will be able to pull it off because it changes a lot of internal work of the Furnace tracker, so I would need to catch all the bugs and properly edit the code in all the places...
