### PR TITLE
Fix wayland icon with SDL_VIDEO_WAYLAND_WMCLASS

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -6744,6 +6744,9 @@ bool FurnaceGUI::init() {
   SDL_SetHint(SDL_HINT_X11_WINDOW_TYPE,"_NET_WM_WINDOW_TYPE_NORMAL");
 #endif
 
+  // This sets the icon in wayland
+  SDL_setenv("SDL_VIDEO_WAYLAND_WMCLASS", FURNACE_APP_ID, 0);
+
   // initialize SDL
   logD("initializing video...");
   if (SDL_Init(SDL_INIT_VIDEO)!=0) {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -36,6 +36,8 @@
 
 #include "fileDialog.h"
 
+#define FURNACE_APP_ID "org.tildearrow.furnace"
+
 #define rightClickable if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) ImGui::SetKeyboardFocusHere(-1);
 #define ctrlWheeling ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) && wheelY!=0)
 


### PR DESCRIPTION
This is used by SDL to set the xdg_toplevel app_id

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
